### PR TITLE
Correct Graph constructor and make internal graph constant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: windows-latest
-            vcpkgCommitId: 'eecae38da7cd35eee7c63d3394eec536a23bea02'
+            vcpkgCommitId: 'cfa560b585b4b17eaa26c74845924fc1f76ef74e'
           - os: ubuntu-latest
-            vcpkgCommitId: 'eecae38da7cd35eee7c63d3394eec536a23bea02'
+            vcpkgCommitId: 'cfa560b585b4b17eaa26c74845924fc1f76ef74e'
           - os: macos-latest
-            vcpkgCommitId: 'eecae38da7cd35eee7c63d3394eec536a23bea02'
+            vcpkgCommitId: 'cfa560b585b4b17eaa26c74845924fc1f76ef74e'
 
     steps:
       - uses: actions/checkout@v3

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -108,7 +108,7 @@ class LIBLEIDENALG_EXPORT Graph
       return get_random_int(0, this->vcount() - 1, rng);
     };
 
-    inline igraph_t* get_igraph() { return this->_graph; };
+    inline const igraph_t* get_igraph() { return this->_graph; };
 
     inline size_t vcount() { return igraph_vcount(this->_graph); };
     inline size_t ecount() { return igraph_ecount(this->_graph); };
@@ -175,7 +175,7 @@ class LIBLEIDENALG_EXPORT Graph
 
     int _remove_graph;
 
-    igraph_t* _graph;
+    const igraph_t* _graph;
     igraph_vector_int_t _temp_igraph_vector;
 
     // Utility variables to easily access the strength of each node

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -263,7 +263,7 @@ Graph::~Graph()
 {
   if (this->_remove_graph)
   {
-    igraph_destroy(this->_graph);
+    igraph_destroy((igraph_t*)this->_graph);
     delete this->_graph;
   }
   igraph_vector_int_destroy(&this->_temp_igraph_vector);

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -259,18 +259,6 @@ Graph::Graph(igraph_t* graph)
   this->set_self_weights();
 }
 
-Graph::Graph()
-{
-  this->_graph = new igraph_t();
-  this->_remove_graph = true;
-  this->set_defaults();
-  this->_is_weighted = false;
-  this->_correct_self_loops = false;
-  igraph_vector_int_init(&this->_temp_igraph_vector, this->vcount());
-  this->init_admin();
-  this->set_self_weights();
-}
-
 Graph::~Graph()
 {
   if (this->_remove_graph)


### PR DESCRIPTION
Fixes #5 by removing the `Graph::Graph()` constructor completely. It was broken, not necessary, and indeed not supported further.

This also includes the suggestion to mark the internal graph `_graph` of the `Graph` class constant.